### PR TITLE
Fix image index variable in feeds, avoiding post array overrrun

### DIFF
--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -69,7 +69,7 @@
                                 </blockquote>
                             </div>
                         <% } else if (posts[i].post.embed_type == "images") { %>
-                            <% for (let j = 0; j < posts[i].post.embed.length; i++) { %>
+                            <% for (let j = 0; j < posts[i].post.embed.length; j++) { %>
                                 <img src="<%= posts[i].post.embed[j].fullsize %>" alt="<%= posts[i].post.embed[j].alt %>" class="embedded-image u-image" />
                             <% } %>
                         <% } %>


### PR DESCRIPTION
using `j` for images, but was incrementing `i` so you'd lose a post per image, then run off the end of the posts array and get an error.

eg https://bsky.link/feed?user=billcherman.bsky.social