### PR TITLE
Use LTS Node.js and drop HTTP request dependencies

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,8 +7,6 @@ const dateFilter = require('nunjucks-date-filter');
 
 const config = require("./config.js");
 
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
-
 const PORT = process.env.PORT || 3008;
 const VALID_URLS = ["bsky.app", "staging.bsky.app"];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,14 @@
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
         "lru-cache": "^9.1.1",
-        "microformats-parser": "^1.4.1",
-        "node-fetch": "^3.3.1",
         "nunjucks": "^3.2.4",
-        "nunjucks-date-filter": "^0.1.1",
-        "xmlhttprequest": "^1.8.0"
+        "nunjucks-date-filter": "^0.1.1"
+      },
+      "devDependencies": {
+        "microformats-parser": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
       }
     },
     "node_modules/a-sync-waterfall": {
@@ -129,14 +132,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -237,28 +232,6 @@
         "express": "^4.16.2"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
@@ -274,17 +247,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/forwarded": {
@@ -427,6 +389,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/microformats-parser/-/microformats-parser-1.4.1.tgz",
       "integrity": "sha512-BSg9Y/Aik8hvvme/fkxnXMRvTKuVwOeTapeZdaPQ+92DEubyM31iMtwbgFZ1383om643UvfYY5G23E9s1FY2KQ==",
+      "dev": true,
       "dependencies": {
         "parse5": "^6.0.0"
       },
@@ -485,41 +448,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
-      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/nunjucks": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
@@ -574,7 +502,8 @@
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -771,22 +700,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "engines": {
-        "node": ">=0.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,13 @@
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
     "lru-cache": "^9.1.1",
-    "microformats-parser": "^1.4.1",
-    "node-fetch": "^3.3.1",
     "nunjucks": "^3.2.4",
-    "nunjucks-date-filter": "^0.1.1",
-    "xmlhttprequest": "^1.8.0"
+    "nunjucks-date-filter": "^0.1.1"
+  },
+  "devDependencies": {
+    "microformats-parser": "^1.4.1"
+  },
+  "engines": {
+    "node": ">=18.12.0"
   }
 }

--- a/tests.js
+++ b/tests.js
@@ -1,4 +1,3 @@
-const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 const { mf2 } = require("microformats-parser");
 
 const ROOT_URL = "http://localhost:3008/?url=";

--- a/tests.js
+++ b/tests.js
@@ -9,19 +9,26 @@ var urls = [
     "https://bsky.app/profile/tudorgirba.com/post/3jutyyruobi22"
 ];
 
-for (var i = 0; i < urls.length; i++) {
-    var url = ROOT_URL + urls[i];
-    fetch(url, {
+Promise.allSettled(urls.map(function (url) {
+    var url = ROOT_URL + url;
+    return fetch(url, {
         method: "GET",
     }).then((response) => {
         var url = response.url;
-        response.text().then((data) => {
+        return response.text().then((data) => {
             var mf2Data = mf2(data, {baseUrl: url});
             if (mf2Data.items.length == 0) {
                 throw Error("No mf2 data found for " + url);
             }
+            return mf2Data;
         });
     });
-}
-
-console.log("All tests passed!");
+})).then(function (testResults) {
+    if (testResults.every(function (promise) {
+        return promise.status === "fulfilled";
+    })) {
+        console.log("All tests passed!");
+    } else {
+        console.log("Some tests failed.");
+    }
+});


### PR DESCRIPTION
Node.js has had native `fetch` for a while now. I would recommend just using the latest LTS release (for all maintenance and security reasons), which also ships with native `fetch`.

This drops `node-fetch` (as well as `xmlhttprequest` that seemed to be unused?) and requires LTS Node.js as the engine.

To make sure everything was still working I also updated tests.js to actually respond correctly. Previously it was not awaiting any of the Promises that were the result of `fetch`, so it was writing out “All tests passed!” before the requests had even finished.

I think tests.js is still a little undercooked. E.g. I tried adding a Bluesky link to `urls` that I knew did not exist, and that still passed the test. This because the bsky.link error page actually resolves as an HTTP 200 page with an `h-entry`. Is this expected?

As the testing is the only thing that does mf2 parsing, I moved the mf2 parser dependency to `devDependencies`. I am not sure how bsky.link is currently served in production, but to not package `microformats-parser` I recommend installing dependencies with: `npm ci --omit="dev"`.