### PR TITLE
Add new config value for domain name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ To run the application, first install the required dependencies:
 npm install
 ```
 
-Then, open `config.js` and add your Bluesky handle and password, like this:
+Then, create `config.js` and add your Bluesky credentials (handle and password) and domain name for the Bluesky Link application, like this:
 ```
 const config = {
     "HANDLE":"yourname.bsky.social",
-    "PASSWORD":"xxxx-xxxx-xxxx-xxxx"
+    "PASSWORD":"xxxx-xxxx-xxxx-xxxx",
+    "DOMAIN":"bsky.domain.example"
 }
 module.exports = config;
 ```

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const nunjucks = require('nunjucks');
 const dateFilter = require('nunjucks-date-filter');
 
 const config = require("./config.js");
+const domain = config.DOMAIN ?? "bsky.link";
 
 const fetch = (...args) => import('node-fetch').then(({default: fetch}) => fetch(...args));
 
@@ -32,6 +33,7 @@ const nun_env = nunjucks.configure('views', {
     autoescape: true, 
     'express': app 
 });
+nun_env.addGlobal('domain', domain);
 nun_env.addFilter('date', dateFilter);
 
 nun_env.addFilter('last_path', function(str) {
@@ -280,7 +282,7 @@ app.route("/").get(async (req, res) => {
 
                     const response_data = {
                         thread: data.thread,
-                        url: "https://bsky.link/" + query_string,
+                        url: "https://"+domain+"/" + query_string,
                         post_url: url,
                         show_thread: show_thread,
                         hide_parent: hide_parent,

--- a/views/error.njk
+++ b/views/error.njk
@@ -7,8 +7,8 @@
         
         <title>Error</title>
 
-        <link rel="icon" href="https://bsky.link/favicon.svg" type="image/svg+xml" />
-        <link rel="icon" href="https://bsky.link/favicon.png" type="image/png" />
+        <link rel="icon" href="https://{{domain}}/favicon.svg" type="image/svg+xml" />
+        <link rel="icon" href="https://{{domain}}/favicon.png" type="image/png" />
 
         <link rel="stylesheet" href="/styles.css">
     </head>

--- a/views/feed.njk
+++ b/views/feed.njk
@@ -14,10 +14,10 @@
         <meta property="article:author" content="{{author}}" />
         <meta name="view-transition" content="same-origin">
 
-        <link rel="alternate" type="application/rss+xml" title="Posts by {{author}}" href=" https://granary.io/url?input=html&output=rss&url=https://bsky.link/feed?user={{author}}" />
+        <link rel="alternate" type="application/rss+xml" title="Posts by {{author}}" href="https://granary.io/url?input=html&output=rss&url=https://{{domain}}/feed?user={{author}}" />
 
-        <link rel="icon" href="https://bsky.link/favicon.svg" type="image/svg+xml" />
-        <link rel="icon" href="https://bsky.link/favicon.png" type="image/png" />
+        <link rel="icon" href="https://{{domain}}/favicon.svg" type="image/svg+xml" />
+        <link rel="icon" href="https://{{domain}}/favicon.png" type="image/png" />
 
         <link rel="stylesheet" href="/styles.css">
     </head>

--- a/views/home.njk
+++ b/views/home.njk
@@ -5,16 +5,16 @@
         
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         
-        <title>bsky.link: Embed Bluesky Posts and Feeds</title>
+        <title>{{domain}}: Embed Bluesky Posts and Feeds</title>
 
         <meta name="description" content="Generate an embeddable link for a Bluesky Post." />
         
-        <meta property="og:title" content="bsky.link: Embed Bluesky Posts and Feeds" />
+        <meta property="og:title" content="{{domain}}: Embed Bluesky Posts and Feeds" />
         <meta property="og:description" content="Generate an embeddable link for a Bluesky Post." />
-        <meta property="og:image" content="https://screenshot.jamesg.blog/?url=https://bsky.link" />
+        <meta property="og:image" content="https://screenshot.jamesg.blog/?url=https://{{domain}}" />
 
-        <link rel="icon" href="https://bsky.link/favicon.svg" type="image/svg+xml" />
-        <link rel="icon" href="https://bsky.link/favicon.png" type="image/png" />
+        <link rel="icon" href="https://{{domain}}/favicon.svg" type="image/svg+xml" />
+        <link rel="icon" href="https://{{domain}}/favicon.png" type="image/png" />
 
         <link rel="stylesheet" href="/styles.css">
 
@@ -26,7 +26,7 @@
     </head>
     <body>
         <main>
-            <h1>bsky.link</h1>
+            <h1>{{domain}}</h1>
             
             <p>Generate embeddable links for Bluesky Posts and subscribable feeds for user pages.</p>
             <div class="tabs">
@@ -47,7 +47,7 @@
 
                 <p>You can generate feeds for user profiles using the following syntax:</p>
 
-                <pre><code>https://bsky.link/feed?user=&lt;handle&gt;</code></pre>
+                <pre><code>https://{{domain}}/feed?user=&lt;handle&gt;</code></pre>
 
                 <p>Where <code>&lt;handle&gt;</code> is the handle of the user (i.e. <code>jamesg.blog</code>).</p>
             </section>
@@ -69,7 +69,7 @@
 
                 <p>You can resolve a DID using the following syntax:</p>
 
-                <pre><code>https://bsky.link/getfeed?handle=&lt;did&gt;</code></pre>
+                <pre><code>https://{{domain}}/getfeed?handle=&lt;did&gt;</code></pre>
 
                 <p>Where <code>&lt;did&gt;</code> is the DID you want to resolve.</p>
             </section>
@@ -100,7 +100,7 @@
 
                 <p>You can create links to share using the following syntax:</p>
 
-                <pre><code>https://bsky.link/?url=https:/bsky.app/profile/&lt;handle&gt;.bsky.social/post/&lt;post_id&gt;</code></pre>
+                <pre><code>https://{{domain}}/?url=https://bsky.app/profile/&lt;handle&gt;.bsky.social/post/&lt;post_id&gt;</code></pre>
 
                 <p>Where <code>&lt;handle&gt;</code> is the handle of the author of the post, and <code>&lt;post_id&gt;</code> is the ID of the post.</p>
 
@@ -115,9 +115,9 @@
             document.getElementById('didform').addEventListener('submit', function(e) {
                 e.preventDefault();
                 
-                var url = 'https://bsky.link/feed?user=' + document.querySelector('input[name="url"]').value;
+                var url = 'https://{{domain}}/feed?user=' + document.querySelector('input[name="url"]').value;
 
-                fetch("https://bsky.link/getfeed?handle=" + document.querySelector('#did').value)
+                fetch("https://{{domain}}/getfeed?handle=" + document.querySelector('#did').value)
                     .then(response => response.json())
                     .then(data => {
                         var handle = data["handle"];
@@ -136,7 +136,7 @@
                 query_parts.push("url="+e.target.elements.url.value);
                 const query_string = "?" + query_parts.join("&");
 
-                const url = new URL("https://bsky.link/"+query_string);
+                const url = new URL("https://{{domain}}/"+query_string);
 
                 const iframe = document.createElement('iframe');
                 iframe.src = url;
@@ -178,7 +178,7 @@
             });
             document.getElementById('feed_embed_form').addEventListener('submit', function(e) {
                 e.preventDefault();
-                const url = new URL("https://bsky.link/feed?user=" + document.getElementById('feed_url').value.toLowerCase());
+                const url = new URL("https://{{domain}}/feed?user=" + document.getElementById('feed_url').value.toLowerCase());
                 const feedUrl = document.createElement('a');
                 feedUrl.href = url;
                 feedUrl.innerText = url;

--- a/views/post.njk
+++ b/views/post.njk
@@ -14,8 +14,8 @@
         <meta property="article:author" content="{{ thread.post.author.handle }}" />
         <meta name="view-transition" content="same-origin">
 
-        <link rel="icon" href="https://bsky.link/favicon.svg" type="image/svg+xml" />
-        <link rel="icon" href="https://bsky.link/favicon.png" type="image/png" />
+        <link rel="icon" href="https://{{domain}}/favicon.svg" type="image/svg+xml" />
+        <link rel="icon" href="https://{{domain}}/favicon.png" type="image/png" />
 
         {% if (thread.post.embed and thread.post.embed.images )  %}
             <meta property="og:image" content="{{ thread.post.embed.images[0].fullsize }}" />


### PR DESCRIPTION
Make it possible to configure the domain name used for the Bluesky Link application. This allows self-hosting it without having a bunch of links and embeds being generated for the original hosted version.

I actually did not realise during testing of the previous PR that the embed within the home page was still being served from the live bsky.link instance. This could have hidden potential bugs from being discovered.