### PR TITLE
Fix “Resolve DID” not working

### DIFF
--- a/app.js
+++ b/app.js
@@ -104,6 +104,10 @@ function getAuthToken () {
 }
 
 function refreshAuthToken () {
+    if (refresh==="") {
+        log("refreshAuthToken called without refresh token;");
+        return getAuthToken();
+    }
     log("refreshAuthToken called with: token='"+token+"'; refresh='"+refresh+"';");
     return fetch("https://bsky.social/xrpc/com.atproto.server.refreshSession", {
         method: "POST",

--- a/views/home.njk
+++ b/views/home.njk
@@ -115,13 +115,11 @@
             document.getElementById('didform').addEventListener('submit', function(e) {
                 e.preventDefault();
                 
-                var url = 'https://{{domain}}/feed?user=' + document.querySelector('input[name="url"]').value;
-
                 fetch("https://{{domain}}/getfeed?handle=" + document.querySelector('#did').value)
                     .then(response => response.json())
                     .then(data => {
                         var handle = data["handle"];
-                        document.querySelector('#did_url').innerHTML = '<a href="' + url + '" target="_blank">' + url + '</a>';
+                        document.querySelector('#didurl').innerHTML = '<a href="https://{{domain}}/feed?user=' + handle + '" target="_blank">' + handle + '</a>';
                     });
             });
             document.querySelector('#embed form').addEventListener('submit', function(e) {


### PR DESCRIPTION
Currently there is a bug when you try to resolve a DID caused by the `querySelector` using the wrong selector.
```
Uncaught (in promise) TypeError: document.querySelector(...) is null
    <anonymous> https://bsky.link/#resolvedid:124
    promise callback* https://bsky.link/#resolvedid:122
    EventListener.handleEvent* https://bsky.link/#resolvedid:115
bsky.link:124:34
```
This fixes that. In addition:

1. What will be displayed will just be the resolved username, linking to that specific user’s feed in bsky.
2. While testing I noticed how I kept doing a dead request at start of bsky when no refresh token existed yet, that is skipped now.